### PR TITLE
Redefine FAN_PIN & add FAN3_PIN allowing (PC8) use as AUTO_FAN_PIN or…

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
@@ -244,7 +244,7 @@
 #define FAN_PIN                             -1    // place holder for non-existant fan - frees up FAN0 for AUTO_FAN_PIN or CONTROLLER_FAN_PIN declaration
 #define FAN1_PIN                            PE5   // Fan1
 #define FAN2_PIN                            PE6   // Fan2
-#define FAN3_PIN			    PC8	  // Fan0
+#define FAN3_PIN                            PC8	  // Fan0
 
 #ifndef E0_AUTO_FAN_PIN
   #define E0_AUTO_FAN_PIN               FAN1_PIN


### PR DESCRIPTION
… CONTROLLER_FAN_PIN

Due to hard-coding in Marlin, it is not possible to declare FAN0 as AUTO_FAN_PIN or CONTROLLER_FAN_PIN.
In this work-around, I redefine FAN_PIN to be -1 to act as a placeholder. FAN3_PIN is then defined as PC8 (FAN0 on the SKR PRO boards) so that this fan pin can freely be used as either AUTO_FAN_PIN or CONTROLLER_FAN_PIN.

### Benefits

<!-- What does this fix or improve? -->

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
