### PR TITLE
Redefine FAN_PIN & add FAN3_PIN for SKR PRO

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
@@ -241,9 +241,10 @@
 #define HEATER_1_PIN                        PD14  // Heater1
 #define HEATER_2_PIN                        PB0   // Heater1
 #define HEATER_BED_PIN                      PD12  // Hotbed
-#define FAN_PIN                             PC8   // Fan0
+#define FAN_PIN                             -1    // place holder for non-existant fan - frees up FAN0 for AUTO_FAN_PIN or CONTROLLER_FAN_PIN declaration
 #define FAN1_PIN                            PE5   // Fan1
 #define FAN2_PIN                            PE6   // Fan2
+#define FAN3_PIN                            PC8   // Fan0
 
 #ifndef E0_AUTO_FAN_PIN
   #define E0_AUTO_FAN_PIN               FAN1_PIN


### PR DESCRIPTION
Redefine FAN_PIN & add FAN3_PIN allowing (PC8) use as AUTO_FAN_PIN or CONTROLLER_FAN_PIN

Due to hard-coding in Marlin, it is not possible to declare FAN0 as AUTO_FAN_PIN or CONTROLLER_FAN_PIN.
In this work-around, I redefine FAN_PIN to be -1 to act as a placeholder. FAN3_PIN is then defined as PC8 (FAN0 on the SKR PRO boards) so that this fan pin can freely be used as either AUTO_FAN_PIN or CONTROLLER_FAN_PIN.

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
